### PR TITLE
Fix return type.Code enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "setbased/phing-extensions": "2.*"
   },
   "require": {
-    "monolog/monolog": "^1.18",
+    "monolog/monolog": "1.*",
     "php": ">=5.4.0",
     "setbased/php-affirm": "*",
     "setbased/php-stratum": "*"

--- a/src/Audit.php
+++ b/src/Audit.php
@@ -179,7 +179,7 @@ class Audit
         $columns = $current_table->main();
         if (empty($columns['altered_columns']))
         {
-          $this->getColumns($current_table->getTableName(), $columns['columns']);
+          $this->getColumns($current_table->getTableName(), $columns['full_columns']);
         }
       }
     }


### PR DESCRIPTION
I think we don't need functions for get new and obsolete columns in Table Class with one line in each function that calling Columns::notInOtherSet , because we can always call Columns::notInOtherSet