### PR TITLE
AUD-62: $auditColumns and $tableColumns mixed up

### DIFF
--- a/src/MySql/DataLayer.php
+++ b/src/MySql/DataLayer.php
@@ -97,8 +97,8 @@ class DataLayer
    * @param string   $tableName       The name of the table.
    * @param string   $triggerAction   The trigger action (i.e. INSERT, UPDATE, or DELETE).
    * @param string   $triggerName     The name of the trigger.
-   * @param Columns  $tableColumns    The data table columns.
    * @param Columns  $auditColumns    The audit table columns.
+   * @param Columns  $tableColumns    The data table columns.
    * @param string   $skipVariable    The skip variable.
    * @param string[] $additionSql     Additional SQL statements.
    */
@@ -107,8 +107,8 @@ class DataLayer
                                             $tableName,
                                             $triggerAction,
                                             $triggerName,
-                                            $tableColumns,
                                             $auditColumns,
+                                            $tableColumns,
                                             $skipVariable,
                                             $additionSql)
   {
@@ -117,8 +117,8 @@ class DataLayer
                                      $tableName,
                                      $triggerAction,
                                      $triggerName,
-                                     $tableColumns,
                                      $auditColumns,
+                                     $tableColumns,
                                      $skipVariable,
                                      $additionSql);
     $sql    = $helper->buildStatement();

--- a/src/MySql/Sql/CreateAuditTrigger.php
+++ b/src/MySql/Sql/CreateAuditTrigger.php
@@ -95,8 +95,8 @@ class CreateAuditTrigger
    * @param string   $tableName       The name of the table.
    * @param string   $triggerAction   The trigger action (i.e. INSERT, UPDATE, or DELETE).
    * @param string   $triggerName     The name of the trigger.
-   * @param Columns  $tableColumns    The data table columns.
    * @param Columns  $auditColumns    The audit table columns.
+   * @param Columns  $tableColumns    The data table columns.
    * @param string   $skipVariable    The skip variable.
    * @param string[] $additionalSql   Additional SQL statements.
    */
@@ -116,8 +116,8 @@ class CreateAuditTrigger
     $this->triggerName     = $triggerName;
     $this->triggerAction   = $triggerAction;
     $this->skipVariable    = $skipVariable;
-    $this->tableColumns    = $tableColumns;
     $this->auditColumns    = $auditColumns;
+    $this->tableColumns    = $tableColumns;
     $this->additionalSql   = $additionalSql;
   }
 


### PR DESCRIPTION
Look at \SetBased\Audit\MySql\Sql\CreateAuditTrigger::__construct. You will see that every where $auditColumns and $tableColumns are mixed up (in assignment, comments).

Everywhere in the code $auditColumns must be before $tableColumns. Aloo in the code that calls the constructor of CreateAuditTrigger, and the code that calls that code, and so on ,and so on.
