### PR TITLE
AUD-63: Wrong type or usage of parameter

### DIFF
--- a/src/MySql/Table/Columns.php
+++ b/src/MySql/Table/Columns.php
@@ -20,18 +20,12 @@ class Columns
   /**
    * Object constructor.
    *
-   * @param array[][] | ColumnType[] $columns The metadata of the columns as returned by DataLayer::getTableColumns().
+   * @param array[] $columns The metadata of the columns as returned by DataLayer::getTableColumns().
    */
   public function __construct($columns)
   {
     foreach ($columns as $column)
     {
-      if (!is_array($column))
-      {
-        /** @var ColumnType $column */
-        $column = $column->getType();
-      }
-      /** @var array $column */
       $this->columns[$column['column_name']] = new ColumnType($column);
     }
   }
@@ -49,14 +43,15 @@ class Columns
   {
     $columns = [];
 
+    /** @var ColumnType $column */
     foreach ($auditColumnsMetadata->columns as $column)
     {
-      $columns[] = $column;
+      $columns[] = $column->getType();
     }
-
+    /** @var ColumnType $column */
     foreach ($currentColumnsMetadata->columns as $column)
     {
-      $columns[] = $column;
+      $columns[] = $column->getType();;
     }
 
     return new Columns($columns);

--- a/src/MySql/Table/Columns.php
+++ b/src/MySql/Table/Columns.php
@@ -20,7 +20,7 @@ class Columns
   /**
    * Object constructor.
    *
-   * @param array[] $columns The metadata of the columns as returned by DataLayer::getTableColumns().
+   * @param array[][] | ColumnType[] $columns The metadata of the columns as returned by DataLayer::getTableColumns().
    */
   public function __construct($columns)
   {

--- a/src/MySql/Table/Columns.php
+++ b/src/MySql/Table/Columns.php
@@ -51,7 +51,7 @@ class Columns
     /** @var ColumnType $column */
     foreach ($currentColumnsMetadata->columns as $column)
     {
-      $columns[] = $column->getType();;
+      $columns[] = $column->getType();
     }
 
     return new Columns($columns);

--- a/src/MySql/Table/Columns.php
+++ b/src/MySql/Table/Columns.php
@@ -72,19 +72,14 @@ class Columns
     $diff = [];
     foreach ($columns2->columns as $column2)
     {
-      if (!is_array($column2))
-      {
-        /** @var ColumnType $column2 */
-        $column2 = $column2->getType();
-      }
+      /** @var ColumnType $column2 */
+      $column2 = $column2->getType();
       if (isset($columns1->columns[$column2['column_name']]))
       {
         $column1 = $columns1->columns[$column2['column_name']];
-        if (!is_array($column1))
-        {
-          /** @var ColumnType $column1 */
-          $column1 = $column1->getType();
-        }
+
+        /** @var ColumnType $column1 */
+        $column1 = $column1->getType();
         if ($column2['column_type']!=$column1['column_type'])
         {
           $diff[] = $column1;
@@ -112,11 +107,8 @@ class Columns
     {
       foreach ($columns1->columns as $column1)
       {
-        if (!is_array($column1))
-        {
-          /** @var ColumnType $column1 */
-          $column1 = $column1->getType();
-        }
+        /** @var ColumnType $column1 */
+        $column1 = $column1->getType();
         if (!isset($columns2->columns[$column1['column_name']]))
         {
           $diff[] = $column1;


### PR DESCRIPTION
In \SetBased\Audit\MySql\Table\Columns::__construct parameter $columns is an array of arrays. So, the !is_array condition does not make sense.

Fix type in docblock or logic in code.
